### PR TITLE
Add the newly required ReadTheDocs YAML

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: conf.py
+
+python:
+  install:
+    - requirements: requirements.txt


### PR DESCRIPTION
Looks like something changed at ReadTheDocs and they now work with a `.readthedocs.yaml` for configuration in a repository.